### PR TITLE
dockerignoreのコメントアウト

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -34,4 +34,4 @@
 /node_modules/
 /app/assets/builds/*
 !/app/assets/builds/.keep
-/public/assets
+#/public/assets


### PR DESCRIPTION
デプロイエラー解消のためdockerignoreのコードをコメントアウトする。